### PR TITLE
Feat: others browsers in requestPairingCode()

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -29,6 +29,7 @@ import {
 	getCodeFromWSError,
 	getErrorCodeFromStreamError,
 	getNextPreKeysNode,
+	getPlatformId,
 	makeEventBuffer,
 	makeNoiseHandler,
 	printQRIfNecessaryListener,
@@ -525,7 +526,7 @@ export const makeSocket = (config: SocketConfig) => {
 						{
 							tag: 'companion_platform_id',
 							attrs: {},
-							content: '49' // Chrome
+							content: getPlatformId(browser[1])
 						},
 						{
 							tag: 'companion_platform_display',

--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -8,6 +8,14 @@ import { version as baileysVersion } from '../Defaults/baileys-version.json'
 import { BaileysEventEmitter, BaileysEventMap, DisconnectReason, WACallUpdateType, WAVersion, BrowsersMap, valueReplacer, valueReviver } from '../Types'
 import { BinaryNode, getAllBinaryNodeChildren, jidDecode } from '../WABinary'
 
+const COMPANION_PLATFORM_MAP = {
+	'Chrome': '49',
+	'Edge': '50',
+	'Firefox': '51',
+	'Opera': '53',
+	'Safari': '54'
+}
+
 const PLATFORM_MAP = {
 	'aix': 'AIX',
 	'darwin': 'Mac OS',
@@ -19,12 +27,16 @@ const PLATFORM_MAP = {
 }
 
 export const Browsers: BrowsersMap = {
-	ubuntu: (browser) => ['Ubuntu', browser, '22.04.4'] as [string, string, string],
-	macOS: (browser) => ['Mac OS', browser, '14.4.1'] as [string, string, string],
-	baileys: (browser) => ['Baileys', browser, '6.5.0'] as [string, string, string],
-	windows: (browser) => ['Windows', browser, '10.0.22631'] as [string, string, string],
+	ubuntu: (browser) => ['Ubuntu', browser, '22.04.4'],
+	macOS: (browser) => ['Mac OS', browser, '14.4.1'],
+	baileys: (browser) => ['Baileys', browser, '6.5.0'],
+	windows: (browser) => ['Windows', browser, '10.0.22631'],
 	/** The appropriate browser based on your OS & release */
-	appropriate: (browser) => [ PLATFORM_MAP[platform()] || 'Ubuntu', browser, release() ] as [string, string, string]
+	appropriate: (browser) => [ PLATFORM_MAP[platform()] || 'Ubuntu', browser, release() ]
+}
+
+export const getPlatformId = (browser: string) => {
+	return COMPANION_PLATFORM_MAP[browser] || '49'
 }
 
 export const BufferJSON = {


### PR DESCRIPTION
Added: Edge, Firefox, Opera and Safari (by default Chrome) with getPlatformId()

Added FreeBSD, OpenBSD and Solaris in PLATFORM_MAP (use with appropriate)

Updated versions of Ubuntu, MacOS, Baileys and Windows

Feat: In requestPairingCode, the default was just chrome, now it is possible to use Edge, Firefox or Opera